### PR TITLE
Adds support for post actions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oznu/s6-alpine:3.11
+FROM oznu/s6-alpine:latest
 LABEL mainainer="Ryan Harter <ryan@ryanharter.com>"
 
 ENV \
@@ -9,12 +9,10 @@ ENV \
 	PGID="" \
 	TZ=""
 
-RUN echo @edge http://nl.alpinelinux.org/alpine/edge/community > /etc/apk/repositories \
-    && echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
- 		&& apk add --no-cache \
- 			goaccess@edge \
- 			nginx@edge \
- 			aws-cli@edge \
+RUN apk add --no-cache \
+ 			goaccess \
+ 			nginx \
+ 			aws-cli \
  		&& rm -rf /var/cache/* \
  		&& mkdir /var/cache/apk
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The following environment variables are used in addition the the standard s6 ove
 | CRON | (Optional) The cron schedule to sync. If missing, the container will perform a one time sync on launch. |
 | HTML_FILENAME | (Optional) The name of the html file to generate (without the extension). This can be used to generate analytics reports for multiple sites. |
 | NO_SERVER | (Optional) If this variable is set then the nginx server won't be started in this container. |
+| POST_ACTION | (Optional) Specify one of the possible post execution actions to take place after the sync script completes.<br/><ul><li>**prune**: Deletes processed log files from S3.</li><li>**script**: A shell script to execute, placed in `/config`.</li><li>**command**: A shell command to execute.</li></ul>
+
+If you specify a `POST_ACTION` script, it will receive the generated analytics HMTL file as `$1`.
 
 ### Volumes
 

--- a/root/app/sync.sh
+++ b/root/app/sync.sh
@@ -12,7 +12,7 @@ echo "INFO: Syncing from bucket s3://${BUCKET}"
 aws s3 sync s3://${BUCKET} /logs
 
 echo "INFO: Generating analytics html from logs."
-zcat /logs/*.gz | goaccess --log-format CLOUDFRONT -a -o /config/html/${HTML_FILENAME:-index}.html -
+zcat /logs/*.gz | goaccess --log-format CLOUDFRONT -a -o /config/html/${HTML_FILENAME:-index}.html --db-path /config/data --persist --restore -
 
 case "$POST_ACTION" in
 	"" )

--- a/root/app/sync.sh
+++ b/root/app/sync.sh
@@ -3,7 +3,7 @@
 echo "INFO: Starting sync.sh PID $$ $(date)"
 
 if [ -z "$BUCKET" ]; then
-	echo "Missing BUCKET environment variable."
+	echo "ERROR: Missing BUCKET environment variable."
 	exit 1
 fi
 
@@ -13,5 +13,40 @@ aws s3 sync s3://${BUCKET} /logs
 
 echo "INFO: Generating analytics html from logs."
 zcat /logs/*.gz | goaccess --log-format CLOUDFRONT -a -o /config/html/${HTML_FILENAME:-index}.html -
+
+case "$POST_ACTION" in
+	"" )
+		;;
+
+	"prune" )
+		PRUNE=1
+		;;
+
+	* )
+		if [ -x "${POST_ACTION}" ]; then
+			echo "INFO: Executing post action script: ${POST_ACTION}"
+			sh -c "${POST_ACTION}" "/config/html/${HTML_FILENAME:-index}.html"
+		elif [ -x "/config/${POST_ACTOIN}" ]; then
+			echo "INFO: Executing post action script: ${POST_ACTION}"
+			sh -c "/config/${POST_ACTION}" "/config/html/${HTML_FILENAME:-index}.html"
+		else
+			echo "INFO: Executing post action: ${POST_ACTION}"
+			eval "${POST_ACTION}"
+		fi
+		;;
+
+esac
+
+if [ -n "$PRUNE" ];then
+	let log_count=$(ls -l /logs | wc -l | awk '{$1=$1};1')-1
+	let prune_count=log_count-1
+	
+	echo "INFO: Pruning ${prune_count} old logs."
+
+	newest_log_filename=$(ls -tp /logs | head -n 1)
+	find /logs/ -type f -not -name "${newest_log_filename}" -delete
+
+	aws s3 sync /logs s3://${BUCKET} --delete
+fi
 
 echo "INFO: Completed sync.sh PID $$ $(date)"

--- a/root/etc/cont-init.d/10-default-content.sh
+++ b/root/etc/cont-init.d/10-default-content.sh
@@ -19,6 +19,11 @@ if [ ! -d /config/html ]; then
   chown -R "${PUID}:${PGID}" /config/html
 fi
 
+if [ ! -d /config/data ]; then
+  mkdir -p /config/data
+  chown -R "${PUID}:${PGID}" /config/data
+fi
+
 if [ ! -f /config/nginx.conf ]; then
 	echo "Copying default nginx.conf file to /config/nginx.conf"
 	cp /defaults/nginx.conf /config/nginx.conf


### PR DESCRIPTION
By setting the `POST_ACTION` environment variable, users can control what happens following a completed log sync and analysis.

While the environment variable can be set to the name of a script file or a shell command, there is also the built in `prune` option, which will delete all but the latest log files (since the latest might be a partial log file, I think, or maybe not, 🤷‍♂️) both locally, and from S3, saving the user megabytes and money.

In some cases a user might want to do some post action **in addition** to pruning, so they could also set the `PRUNE` environment variable and also set the `POST_ACTION variable to something else.  This is considered a pro feature so isn't documented in the readme.