### PR TITLE
Update to support multiple architectures!

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
     tags:
       - '*'
 
@@ -15,11 +16,48 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v2
 
-      - name: Build 🛠
-        uses: docker/build-push-action@v1
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=rharter/goaccess-cloudfront
+          VERSION=edge
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+          VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+          TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
         with:
           username: rharter
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: rharter/goaccess-cloudfront
-          tag_with_ref: true
-          add_git_labels: true
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge AS build
+FROM alpine:3.12 AS build
 RUN apk add --no-cache \
     autoconf \
     automake \
@@ -26,7 +26,7 @@ RUN autoreconf -fiv \
     && make \
     && make DESTDIR=/dist install
 
-FROM oznu/s6-alpine:3.12
+FROM crazymax/alpine-s6:3.12
 LABEL mainainer="Ryan Harter <ryan@ryanharter.com>"
 
 COPY --from=build /dist /

--- a/root/app/sync.sh
+++ b/root/app/sync.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/with-contenv sh
 
+export AWS_SHARED_CREDENTIALS_FILE=/config/.aws/credentials
+export AWS_CONFIG_FILE=/config/.aws/config
+
 echo "INFO: Starting sync.sh PID $$ $(date)"
 
 if [ -z "$BUCKET" ]; then

--- a/root/etc/cont-init.d/10-adduser.sh
+++ b/root/etc/cont-init.d/10-adduser.sh
@@ -23,8 +23,8 @@
 PUID=${PUID:-911}
 PGID=${PGID:-911}
 
-groupmod -o -g "$PGID" abc
-usermod -o -u "$PUID" abc
+addgroup -g "${PUID}" -S abc
+adduser -u "${PUID}" -S abc -G abc
 
 echo "
 Initializing container


### PR DESCRIPTION
https://github.com/docker/build-push-action#multi-platform-image

Upgrade from docker/build-push-action v1 to v2: https://github.com/docker/build-push-action/blob/master/UPGRADE.md#tags-with-ref-and-git-labels

Build base image changed from edge to 3.12 because of openssl error.
```
#90 [linux/arm64 build 6/6] RUN autoreconf -fiv     && CC="clang" CFLAGS="-O...
#90 CANCELED
------
 > [linux/amd64 build 6/6] RUN autoreconf -fiv     && CC="clang" CFLAGS="-O3 -static" LIBS="$(pkg-config --libs openssl)" ./configure --prefix="" --enable-utf8 --with-openssl --enable-geoip=mmdb     && make     && make DESTDIR=/dist install:
------
failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c autoreconf -fiv     && CC="clang" CFLAGS="-O3 -static" LIBS="$(pkg-config --libs openssl)" ./configure --prefix="" --enable-utf8 --with-openssl --enable-geoip=mmdb     && make     && make DESTDIR=/dist install]: exit code: 1
Error: buildx call failed with: failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c autoreconf -fiv     && CC="clang" CFLAGS="-O3 -static" LIBS="$(pkg-config --libs openssl)" ./configure --prefix="" --enable-utf8 --with-openssl --enable-geoip=mmdb     && make     && make DESTDIR=/dist install]: exit code: 1
```

Main base image changed to https://github.com/crazy-max/docker-alpine-s6 in order to easily support multiple base architectures.

Closes #11